### PR TITLE
Refactor table retrieval getDoctrineSchemaManager removed in laravel 11

### DIFF
--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -179,7 +179,7 @@ class RoleController extends Controller
     {
         $prem = Permission::all()->makeHidden(['pivot', 'created_at', 'updated_at']);
 
-        $tables = DB::connection()->getDoctrineSchemaManager()->listTableNames();
+        $tables = array_map('current', DB::select('SHOW TABLES'));
 
         $permGroup = [];
         foreach ($tables as $item) {


### PR DESCRIPTION
I updated a file to support Laravel 11 by refactoring the table retrieval, as the getDoctrineSchemaManager function was removed in Laravel 11.
I welcome any questions or feedback regarding this change request. This is my first contribution to a GitHub repository, so I'm open to suggestions and guidance.